### PR TITLE
GDB-3857 Added check for IndexFormatTooOldException during initializa…

### DIFF
--- a/src/main/java/com/ontotext/trree/plugin/autocomplete/AutocompleteIndex.java
+++ b/src/main/java/com/ontotext/trree/plugin/autocomplete/AutocompleteIndex.java
@@ -117,6 +117,9 @@ class AutocompleteIndex {
         } catch (IOException e) {
             if (e instanceof IndexFormatTooOldException) {
                 try {
+                    // If created index is older version during creation of suggester
+                    // is thrown IndexFormatTooOldException, directory and settings should
+                    // be cleared and afterwards restarted with current Lucene version
                     FileUtils.deleteDirectory(autocompletePlugin.getDataDir());
                     this.autocompletePlugin.isPluginEnabled = false;
                     restartLuceneConfig();


### PR DESCRIPTION
…tion of Lucene config. In this case proper message "Upgrade detected. Current autocomplete index is created with previous GraphDB version. Please recreate index" is returned to the user and directory is deleted.