### PR TITLE
GDB-10567: Introduce 'if' condition that ensures the correct ordering…

### DIFF
--- a/src/main/java/com/ontotext/trree/plugin/autocomplete/AutocompletePlugin.java
+++ b/src/main/java/com/ontotext/trree/plugin/autocomplete/AutocompletePlugin.java
@@ -115,6 +115,9 @@ public class AutocompletePlugin extends PluginBase
     public double estimate(long subject, long predicate, long object, long context, PluginConnection pluginConnection,
                            RequestContext requestContext) {
         if (predicate == queryPredicateId || context == controlContextId)  {
+            if (subject == Entities.UNBOUND) {
+                return Double.MIN_VALUE;
+            }
             return Double.POSITIVE_INFINITY;
         } else {
             return 0;

--- a/src/test/java/com/ontotext/trree/plugin/autocomplete/AutocompletePluginTestBase.java
+++ b/src/test/java/com/ontotext/trree/plugin/autocomplete/AutocompletePluginTestBase.java
@@ -185,6 +185,12 @@ public abstract class AutocompletePluginTestBase extends SingleRepositoryFunctio
 		TupleQuery tq = connection.prepareTupleQuery(QueryLanguage.SPARQL, sparqlQuery);
 		return getFoundSubjects(tq.evaluate());
 	}
+	List<String> executeCustomQueryAndGetResults(String sparqlQueryStart, String sparqlQueryEnd, String pluginQuery)
+			throws RepositoryException, MalformedQueryException, QueryEvaluationException {
+		String finalQuery = sparqlQueryStart + pluginQuery + sparqlQueryEnd;
+		TupleQuery tq = connection.prepareTupleQuery(QueryLanguage.SPARQL, finalQuery);
+		return getFoundSubjects(tq.evaluate());
+	}
 	void importData(String fileName, RDFFormat format) throws RepositoryException, IOException, RDFParseException {
 		connection.begin();
 		connection.add(new File(fileName), "urn:base", format);


### PR DESCRIPTION
… of the autocomplete index during query optimization

* The triple containing the auto:query predicate will now always be evaluated first regardless of its placement in the query, as long as the subject of the triple is unbounded

Closes [GDB-10567](https://ontotext.atlassian.net/browse/GDB-10567?focusedCommentId=157600&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-157600).