### PR TITLE
GDB-11733 Fix any failing plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <version>4.2-SNAPSHOT</version>
 
     <properties>
-        <graphdb.version>10.7.1-RC2</graphdb.version>
+        <graphdb.version>10.8.4</graphdb.version>
 
         <java.level>1.8</java.level>
 
@@ -208,7 +208,7 @@
         <dependency>
             <groupId>com.ontotext.graphdb.plugins</groupId>
             <artifactId>rdfrank-plugin</artifactId>
-            <version>1.0.0-RC1</version>
+            <version>1.2.0</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Updated rdfrank-plugin as the old version isn't compatible with GraphDB 11 (tested TR12)

Updated GraphDB version to latest released version